### PR TITLE
Restore LevelLoaderExample

### DIFF
--- a/assets/level/example.lvl
+++ b/assets/level/example.lvl
@@ -29,17 +29,17 @@
 	<entity x="208" y="48" width="16" height="16" type="box"/>
 	<entity x="208" y="64" width="16" height="16" type="box"/>
 	<entity x="208" y="80" width="16" height="16" type="box"/>
-	<entity x="224" y="80" width="16" height="16" type="box"/>
-	<entity x="240" y="80" width="16" height="16" type="box"/>
-	<entity x="256" y="80" width="16" height="16" type="box"/>
+	<entity x="224" y="16" width="16" height="16" type="box"/>
+	<entity x="240" y="16" width="16" height="16" type="box"/>
+	<entity x="256" y="16" width="16" height="16" type="box"/>
 	<entity x="288" y="16" width="16" height="16" type="box"/>
 	<entity x="288" y="32" width="16" height="16" type="box"/>
 	<entity x="288" y="48" width="16" height="16" type="box"/>
 	<entity x="288" y="64" width="16" height="16" type="box"/>
 	<entity x="288" y="80" width="16" height="16" type="box"/>
-	<entity x="304" y="80" width="16" height="16" type="box"/>
-	<entity x="320" y="80" width="16" height="16" type="box"/>
-	<entity x="336" y="80" width="16" height="16" type="box"/>
+	<entity x="304" y="16" width="16" height="16" type="box"/>
+	<entity x="320" y="16" width="16" height="16" type="box"/>
+	<entity x="336" y="16" width="16" height="16" type="box"/>
 	<entity x="368" y="16" width="16" height="16" type="box"/>
 	<entity x="368" y="32" width="16" height="16" type="box"/>
 	<entity x="368" y="48" width="16" height="16" type="box"/>
@@ -54,44 +54,9 @@
 	<entity x="416" y="48" width="16" height="16" type="box"/>
 	<entity x="416" y="64" width="16" height="16" type="box"/>
 	<entity x="416" y="80" width="16" height="16" type="box"/>
-	<entity x="208" y="112" width="16" height="16" type="box"/>
-	<entity x="224" y="112" width="16" height="16" type="box"/>
-	<entity x="240" y="112" width="16" height="16" type="box"/>
-	<entity x="256" y="112" width="16" height="16" type="box"/>
-	<entity x="272" y="112" width="16" height="16" type="box"/>
-	<entity x="192" y="128" width="16" height="16" type="box"/>
-	<entity x="176" y="144" width="16" height="16" type="box"/>
-	<entity x="160" y="160" width="16" height="16" type="box"/>
-	<entity x="160" y="176" width="16" height="16" type="box"/>
-	<entity x="160" y="192" width="16" height="16" type="box"/>
-	<entity x="160" y="208" width="16" height="16" type="box"/>
-	<entity x="160" y="224" width="16" height="16" type="box"/>
-	<entity x="160" y="240" width="16" height="16" type="box"/>
-	<entity x="176" y="256" width="16" height="16" type="box"/>
-	<entity x="192" y="272" width="16" height="16" type="box"/>
-	<entity x="208" y="288" width="16" height="16" type="box"/>
-	<entity x="224" y="288" width="16" height="16" type="box"/>
-	<entity x="240" y="288" width="16" height="16" type="box"/>
-	<entity x="256" y="288" width="16" height="16" type="box"/>
-	<entity x="272" y="288" width="16" height="16" type="box"/>
-	<entity x="288" y="272" width="16" height="16" type="box"/>
-	<entity x="304" y="256" width="16" height="16" type="box"/>
-	<entity x="320" y="240" width="16" height="16" type="box"/>
-	<entity x="320" y="224" width="16" height="16" type="box"/>
-	<entity x="320" y="208" width="16" height="16" type="box"/>
-	<entity x="320" y="192" width="16" height="16" type="box"/>
-	<entity x="320" y="176" width="16" height="16" type="box"/>
-	<entity x="320" y="160" width="16" height="16" type="box"/>
-	<entity x="304" y="144" width="16" height="16" type="box"/>
-	<entity x="288" y="128" width="16" height="16" type="box"/>
-	<entity x="208" y="160" width="32" height="32" type="hexagon"/>
-	<entity x="256" y="160" width="32" height="32" type="hexagon"/>
-	<entity x="192" y="224" width="16" height="16" type="box"/>
-	<entity x="208" y="240" width="16" height="16" type="box"/>
-	<entity x="224" y="256" width="16" height="16" type="box"/>
-	<entity x="240" y="256" width="16" height="16" type="box"/>
-	<entity x="256" y="256" width="16" height="16" type="box"/>
-	<entity x="272" y="240" width="16" height="16" type="box"/>
-	<entity x="288" y="224" width="16" height="16" type="box"/>
-	<entity x="240" y="208" width="16" height="16" type="circle"/>
+
+	<entity x="240" y="208" width="160" height="160" type="circle">
+		<entity x="55" y="94" width="32" height="32" type="hexagon"/>
+		<entity x="108" y="94" width="32" height="32" type="hexagon"/>
+	</entity>
 </level>

--- a/src/org/andengine/examples/LevelLoaderExample.java
+++ b/src/org/andengine/examples/LevelLoaderExample.java
@@ -23,6 +23,7 @@ import org.andengine.ui.activity.SimpleBaseGameActivity;
 import org.andengine.util.SAXUtils;
 import org.andengine.util.debug.Debug;
 import org.andengine.util.level.EntityLoader;
+import org.andengine.util.level.LevelUtils;
 import org.andengine.util.level.constants.LevelConstants;
 import org.andengine.util.level.simple.SimpleLevelEntityLoaderData;
 import org.andengine.util.level.simple.SimpleLevelLoader;
@@ -48,10 +49,6 @@ public class LevelLoaderExample extends SimpleBaseGameActivity {
 	private static final int CAMERA_HEIGHT = 320;
 
 	private static final String TAG_ENTITY = "entity";
-	private static final String TAG_ENTITY_ATTRIBUTE_X = "x";
-	private static final String TAG_ENTITY_ATTRIBUTE_Y = "y";
-	private static final String TAG_ENTITY_ATTRIBUTE_WIDTH = "width";
-	private static final String TAG_ENTITY_ATTRIBUTE_HEIGHT = "height";
 	private static final String TAG_ENTITY_ATTRIBUTE_TYPE = "type";
 
 	private static final Object TAG_ENTITY_ATTRIBUTE_TYPE_VALUE_BOX = "box";
@@ -132,26 +129,24 @@ public class LevelLoaderExample extends SimpleBaseGameActivity {
 		levelLoader.registerEntityLoader(new EntityLoader<SimpleLevelEntityLoaderData>(TAG_ENTITY) {
 			@Override
 			public IEntity onLoadEntity(final String pEntityName, final IEntity pParent, final Attributes pAttributes, final SimpleLevelEntityLoaderData pSimpleLevelEntityLoaderData) throws IOException {
-				final int x = SAXUtils.getIntAttributeOrThrow(pAttributes, TAG_ENTITY_ATTRIBUTE_X);
-				final int y = SAXUtils.getIntAttributeOrThrow(pAttributes, TAG_ENTITY_ATTRIBUTE_Y);
-				final int width = SAXUtils.getIntAttributeOrThrow(pAttributes, TAG_ENTITY_ATTRIBUTE_WIDTH);
-				final int height = SAXUtils.getIntAttributeOrThrow(pAttributes, TAG_ENTITY_ATTRIBUTE_HEIGHT);
 				final String type = SAXUtils.getAttributeOrThrow(pAttributes, TAG_ENTITY_ATTRIBUTE_TYPE);
 
 				final VertexBufferObjectManager vertexBufferObjectManager = pSimpleLevelEntityLoaderData.getVertexBufferObjectManager();
 
 				final AnimatedSprite animatedSprite;
 				if(type.equals(TAG_ENTITY_ATTRIBUTE_TYPE_VALUE_BOX)) {
-					animatedSprite = new AnimatedSprite(x, y, width, height, LevelLoaderExample.this.mBoxFaceTextureRegion, vertexBufferObjectManager);
+					animatedSprite = new AnimatedSprite(0, 0, LevelLoaderExample.this.mBoxFaceTextureRegion, vertexBufferObjectManager);
 				} else if(type.equals(TAG_ENTITY_ATTRIBUTE_TYPE_VALUE_CIRCLE)) {
-					animatedSprite = new AnimatedSprite(x, y, width, height, LevelLoaderExample.this.mCircleFaceTextureRegion, vertexBufferObjectManager);
+					animatedSprite = new AnimatedSprite(0, 0, LevelLoaderExample.this.mCircleFaceTextureRegion, vertexBufferObjectManager);
 				} else if(type.equals(TAG_ENTITY_ATTRIBUTE_TYPE_VALUE_TRIANGLE)) {
-					animatedSprite = new AnimatedSprite(x, y, width, height, LevelLoaderExample.this.mTriangleFaceTextureRegion, vertexBufferObjectManager);
+					animatedSprite = new AnimatedSprite(0, 0, LevelLoaderExample.this.mTriangleFaceTextureRegion, vertexBufferObjectManager);
 				} else if(type.equals(TAG_ENTITY_ATTRIBUTE_TYPE_VALUE_HEXAGON)) {
-					animatedSprite = new AnimatedSprite(x, y, width, height, LevelLoaderExample.this.mHexagonFaceTextureRegion, vertexBufferObjectManager);
+					animatedSprite = new AnimatedSprite(0, 0, LevelLoaderExample.this.mHexagonFaceTextureRegion, vertexBufferObjectManager);
 				} else {
 					throw new IllegalArgumentException();
 				}
+				LevelUtils.setPosition(pAttributes, animatedSprite);
+				LevelUtils.setSize(pAttributes, animatedSprite);
 
 				animatedSprite.animate(200);
 

--- a/src/org/andengine/examples/launcher/Example.java
+++ b/src/org/andengine/examples/launcher/Example.java
@@ -27,6 +27,7 @@ import org.andengine.examples.EntityModifierIrregularExample;
 import org.andengine.examples.GradientExample;
 import org.andengine.examples.HullAlgorithmExample;
 import org.andengine.examples.ImageFormatsExample;
+import org.andengine.examples.LevelLoaderExample;
 import org.andengine.examples.LineExample;
 import org.andengine.examples.LoadTextureExample;
 import org.andengine.examples.MenuExample;
@@ -133,7 +134,7 @@ enum Example {
 	GRADIENT(GradientExample.class, R.string.example_gradient),
 	HULLALGORITHM(HullAlgorithmExample.class, R.string.example_hullalgorithm),
 	IMAGEFORMATS(ImageFormatsExample.class, R.string.example_imageformats),
-//	LEVELLOADER(LevelLoaderExample.class, R.string.example_levelloader),
+	LEVELLOADER(LevelLoaderExample.class, R.string.example_levelloader),
 	LINE(LineExample.class, R.string.example_line),
 	LOADTEXTURE(LoadTextureExample.class, R.string.example_loadtexture),
 	MENU(MenuExample.class, R.string.example_menu),

--- a/src/org/andengine/examples/launcher/ExampleGroup.java
+++ b/src/org/andengine/examples/launcher/ExampleGroup.java
@@ -118,7 +118,7 @@ public enum ExampleGroup {
 			Example.RUNNABLEPOOLUPDATEHANDLER,
 			Example.SVGTEXTUREREGION,
 			Example.XMLLAYOUT,
-//			Example.LEVELLOADER,
+			Example.LEVELLOADER,
 			Example.CCBLEVELLOADER
 		),
 	APP(R.string.examplegroup_app,

--- a/src/org/andengine/examples/launcher/ExampleLauncher.java
+++ b/src/org/andengine/examples/launcher/ExampleLauncher.java
@@ -58,7 +58,7 @@ public class ExampleLauncher extends ExpandableListActivity {
 	public void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		if(!AndEngine.isDeviceSupported()) {
+		if(!AndEngine.isDeviceSupported(this)) {
 			this.showDialog(ExampleLauncher.DIALOG_DEVICE_NOT_SUPPORTED);
 		}
 


### PR DESCRIPTION
Along with restoring LevelLoaderExample and fixing the example.lvl
this patch also makes use of LevelLoaderUtils- new utility class to
simplify working with XML-based leveles.

It shows how position and size of an Entity can be easily restored from level description using LevelLoaderUtils. It still does not show how to dump a level, though. 
