### PR TITLE
Updated AndEngine.isDeviceSupported in ExampleLauncher.java to fix compi...

### DIFF
--- a/src/org/andengine/examples/launcher/ExampleLauncher.java
+++ b/src/org/andengine/examples/launcher/ExampleLauncher.java
@@ -58,7 +58,7 @@ public class ExampleLauncher extends ExpandableListActivity {
 	public void onCreate(final Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 
-		if(!AndEngine.isDeviceSupported()) {
+		if(!AndEngine.isDeviceSupported(this.getApplicationContext())) {
 			this.showDialog(ExampleLauncher.DIALOG_DEVICE_NOT_SUPPORTED);
 		}
 


### PR DESCRIPTION
Updated AndEngine.isDeviceSupported in ExampleLauncher.java to fix compile error with current version of AndEngine GLES2-AnchorCenter.

After setting up my work environment ExampleLauncher was calling AndEngine.isDeviceSupport() without any arguments but the latest version of GLES2-AnchorCenter requires context to be passed to isDeviceSupport. This has been updated with this.getApplicationContext().
